### PR TITLE
Added null check in generateStackTrace

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -52,9 +52,13 @@ Bugsense.Errors = (function () {
 
   var generateStackTrace = function(error) {
     var stack = TraceKit.computeStackTrace(error).stack;
-    return stack.map(function (s) {
-      return s.func+"@"+s.url+":"+s.line;
-    });
+    if (stack) {
+      return stack.map(function(s) {
+        return s.func+"@"+s.url+":"+s.line;
+      });
+    } else {
+      return [];
+    }
   };
   var getStackTrace = function(error) {
     return error.stack || generateStackTrace(error);


### PR DESCRIPTION
The stack returned can be null which can cause an error when stack.map
is performed.
