### PR TITLE
Do not return false from onerror handler. Fixes #27

### DIFF
--- a/specs/notifySpecs.js
+++ b/specs/notifySpecs.js
@@ -39,7 +39,6 @@ describe("Bugsense::Notify server", function(){
         { "Content-Type": "application/json" },
         JSON.stringify({eid: '123123123'})
     );
-    expect(response).toBe(false);
 
     var req = server.requests[0]
     var url = req.url.split('=');

--- a/src/errors.js
+++ b/src/errors.js
@@ -69,7 +69,6 @@ Bugsense.Errors = (function () {
     parsedError = parse(data);
 
     Bugsense.Network.send(generateExceptionData(parsedError), 'POST');
-    return false;
   };
 
   window.onerror = function(exception, url, line, column, errorobj) {
@@ -77,7 +76,7 @@ Bugsense.Errors = (function () {
       if(Bugsense.config.apiKey) {
         Bugsense.trigger('crash');
 
-        return Bugsense.notify({
+        Bugsense.notify({
           exception: exception,
           url: url,
           line: line,
@@ -88,10 +87,8 @@ Bugsense.Errors = (function () {
         var msg = 'You need a BugSense API key to use bugsense.js.';
         if('warn' in console) console.warn(msg)
         else console.log(msg);
-        return false
       }
     }
-    return false;
   };
 
   return {


### PR DESCRIPTION
Since bugsense's handler do not need to suppress error handling there is no need to return anything from onerror handler.
Older Opera and Chrome have onerror handler return value semantics inverted:
http://stackoverflow.com/questions/8087240/if-i-override-window-onerror-in-javascript-should-i-return-true-or-false
Therefore, it's even safer to avoid returning anything from onerror.
